### PR TITLE
Preserve data on non-active items for PopModel

### DIFF
--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -157,12 +157,13 @@ class URAlgorithm(val ap: URAlgorithmParams)
     } else None
 
     val allPropertiesRDD = if (popModel.nonEmpty) {
-      data.fieldsRDD.cogroup[Float](popModel.get).map { case (item, pms) =>
-        val pm = if (pms._1.nonEmpty && pms._2.nonEmpty) {
-          val newPM = pms._1.head.fields + (backfillFieldName -> JDouble(pms._2.head))
-          PropertyMap(newPM, pms._1.head.firstUpdated, DateTime.now())
-        } else if (pms._2.nonEmpty) PropertyMap(Map(backfillFieldName -> JDouble(pms._2.head)), DateTime.now(), DateTime.now())
-        else PropertyMap( Map.empty[String, JValue], DateTime.now, DateTime.now) // some error????
+      data.fieldsRDD.cogroup[Float](popModel.get).map { case (item, (pms, scores)) =>
+        val score = scores.map(s => backfillFieldName -> JDouble(s)).toMap
+        val pm = pms.headOption.map { pm =>
+          PropertyMap(pm.fields ++ score, pm.firstUpdated, DateTime.now)
+        }.getOrElse {
+          PropertyMap(score, DateTime.now, DateTime.now)
+        }
         (item, pm)
       }
     } else data.fieldsRDD


### PR DESCRIPTION
Model:
- 100 items (1-100) with properties
- 100 main events.
- Events during last days (backfillField.duration) only for top 10 Items (91-100)
- Engine with `"recsModel": "all"`

Training:
https://github.com/PredictionIO/template-scala-parallel-universal-recommendation/blob/v0.2.3/src/main/scala/URAlgorithm.scala#L152-L168
- As we have `"recsModel": "all"` (`popular=true`) we calculate PopModel
- PopModel using events only for backfillField.duration, so we got pop results only for items 91-100
- Then we combine data form `allFields` with `popModel`

``` scala
      val pm = if (pms._1.nonEmpty && pms._2.nonEmpty) {
          val newPM = pms._1.head.fields + (backfillFieldName -> JDouble(pms._2.head))
          PropertyMap(newPM, pms._1.head.firstUpdated, DateTime.now())
        } else if (pms._2.nonEmpty) PropertyMap(Map(backfillFieldName -> JDouble(pms._2.head)), DateTime.now(), DateTime.now())
        else PropertyMap( Map.empty[String, JValue], DateTime.now, DateTime.now) // some error????
```
- As we don't have popularity for items 1-90 we get empty properties for all that items

Query:
- If we use date filters we will select only from items 91-100 (as all other items missed date properties)
- Boost/filter by fields works only on items 91-100

Solution:
- Preserve data on non-active items
