### PR TITLE
Update of the elasticsearch-spark dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   // other external libs
   "com.thoughtworks.xstream" % "xstream" % "1.4.4"
     exclude("xmlpull", "xmlpull"),
-  "org.elasticsearch" % "elasticsearch-spark_2.10" % "2.1.0.Beta4"
+  "org.elasticsearch" % "elasticsearch-spark_2.10" % "2.2.0"
     exclude("org.apache.spark", "spark-catalyst_2.10")
     exclude("org.apache.spark", "spark-sql_2.10"),
   "org.json4s" %% "json4s-native" % "3.2.11"


### PR DESCRIPTION
As outlined at https://github.com/PredictionIO/template-scala-parallel-universal-recommendation/issues/34#issuecomment-182951307 this fixes the error message from https://github.com/elastic/elasticsearch-hadoop/issues/616
